### PR TITLE
Bridge CF types and blocks

### DIFF
--- a/CoreFoundation.xcodeproj/project.pbxproj
+++ b/CoreFoundation.xcodeproj/project.pbxproj
@@ -1304,6 +1304,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				LINK_WITH_STANDARD_LIBRARIES = YES;
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
 					"-licucore.A",
 					"-lxml2",
@@ -1350,6 +1351,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				LINK_WITH_STANDARD_LIBRARIES = YES;
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
 					"-licucore.A",
 					"-lxml2",

--- a/CoreFoundation/AppServices.subproj/CFNotificationCenter.c
+++ b/CoreFoundation/AppServices.subproj/CFNotificationCenter.c
@@ -159,7 +159,7 @@ static CFTypeID __kCFNotificationCenterTypeID = _kCFRuntimeNotATypeID;
 // This must be called from __CFInitialize in CFRuntime.h before notification centers can be used
 __private_extern__ void __CFNotificationCenterInitialize(void) {
 	__kCFNotificationCenterTypeID = _CFRuntimeRegisterClass(&__CFNotificationCenterClass);
-	__CFHashStore = CFDictionaryCreateMutable( kCFAllocatorDefault, 0, NULL, NULL );
+	__CFHashStore = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, NULL, NULL);
 }
 
 CFTypeID CFNotificationCenterGetTypeID(void) {

--- a/CoreFoundation/Base.subproj/CFBase.c
+++ b/CoreFoundation/Base.subproj/CFBase.c
@@ -581,20 +581,20 @@ void *CFAllocatorAllocate(CFAllocatorRef allocator, CFIndex size, CFOptionFlags 
     void *newptr = NULL;
 
     if (NULL == allocator) {
-	allocator = __CFGetDefaultAllocator();
+        allocator = __CFGetDefaultAllocator();
     }
 
 #if defined(DEBUG) && (DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI)
     if (allocator->_base._cfisa == __CFISAForTypeID(__kCFAllocatorTypeID)) {
-	__CFGenericValidateType(allocator, __kCFAllocatorTypeID);
+        __CFGenericValidateType(allocator, __kCFAllocatorTypeID);
     }
 #else
     __CFGenericValidateType(allocator, __kCFAllocatorTypeID);
 #endif
     if (0 == size) return NULL;
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI
-    if (allocator->_base._cfisa != __CFISAForTypeID(__kCFAllocatorTypeID)) {	// malloc_zone_t *
-	return malloc_zone_malloc((malloc_zone_t *)allocator, size);
+    if (allocator->_base._cfisa != __CFISAForTypeID(__kCFAllocatorTypeID)) {    // malloc_zone_t *
+        return malloc_zone_malloc((malloc_zone_t *)allocator, size);
     }
 #endif
     newptr = NULL;
@@ -673,20 +673,21 @@ void CFAllocatorDeallocate(CFAllocatorRef allocator, void *ptr) {
 
 #if defined(DEBUG) && (DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI)
     if (allocator->_base._cfisa == __CFISAForTypeID(__kCFAllocatorTypeID)) {
-	__CFGenericValidateType(allocator, __kCFAllocatorTypeID);
+        __CFGenericValidateType(allocator, __kCFAllocatorTypeID);
     }
 #else
     __CFGenericValidateType(allocator, __kCFAllocatorTypeID);
 #endif
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI
-    if (allocator->_base._cfisa != __CFISAForTypeID(__kCFAllocatorTypeID)) {	// malloc_zone_t *
+    if (allocator->_base._cfisa != __CFISAForTypeID(__kCFAllocatorTypeID)) {    // malloc_zone_t *
 #if defined(DEBUG)
-	size_t size = malloc_size(ptr);
-	if (size) memset(ptr, 0xCC, size);
+        size_t size = malloc_size(ptr);
+        if (size) memset(ptr, 0xCC, size);
 #endif
-	return malloc_zone_free((malloc_zone_t *)allocator, ptr);
+        return malloc_zone_free((malloc_zone_t *)allocator, ptr);
     }
 #endif
+
     deallocateFunc = __CFAllocatorGetDeallocateFunction(&allocator->_context);
     if (NULL != ptr && NULL != deallocateFunc) {
 	INVOKE_CALLBACK2(deallocateFunc, ptr, allocator->_context.info);

--- a/CoreFoundation/Base.subproj/CFUtilities.c
+++ b/CoreFoundation/Base.subproj/CFUtilities.c
@@ -617,15 +617,15 @@ static void _CFShowToFile(FILE *file, Boolean flush, const void *obj) {
      bool lastNL = false;
 
      if (obj) {
-	if (CFGetTypeID(obj) == CFStringGetTypeID()) {
-	    // Makes Ali marginally happier
-	    str = __CFCopyFormattingDescription(obj, NULL);
-	    if (!str) str = CFCopyDescription(obj);
-	} else {
-	    str = CFCopyDescription(obj);
-	}
+         if (CFGetTypeID(obj) == CFStringGetTypeID()) {
+             // Makes Ali marginally happier
+             str = __CFCopyFormattingDescription(obj, NULL);
+             if (!str) str = CFCopyDescription(obj);
+         } else {
+             str = CFCopyDescription(obj);
+         }
      } else {
-	str = (CFStringRef)CFRetain(CFSTR("(null)"));
+         str = (CFStringRef)CFRetain(CFSTR("(null)"));
      }
      cnt = CFStringGetLength(str);
 

--- a/CoreFoundation/Error.subproj/CFError.c
+++ b/CoreFoundation/Error.subproj/CFError.c
@@ -127,9 +127,7 @@ static CFStringRef __CFErrorCopyDescription(CFTypeRef cf) {
 /* This is the description you get for %@. Note that this used to return the shorter description prior to 10.11/iOS9; moving forward we just generate the same result.  In general this function is rarely invoked, so shouldn't matter much.
 */
 static CFStringRef __CFErrorCopyFormattingDescription(CFTypeRef cf, CFDictionaryRef formatOptions) {
-    if (
-        true
-        ) {
+    if (true) {
         return _CFErrorCreateDebugDescription((CFErrorRef)cf);
     } else {
         return CFErrorCopyDescription((CFErrorRef)cf);

--- a/PureFoundation/NSArray.m
+++ b/PureFoundation/NSArray.m
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "ForFoundationOnly.h"
 #import "PureFoundation.h"
 #import "FileLoaders.h"
 
@@ -525,11 +526,14 @@ static void PFArrayMakePerformSelector(const void *value, void *context) {
 }
 
 // Standard bridged-class over-rides
-- (id)retain { return (id)CFRetain((CFTypeRef)self); }
+- (id)retain { return (id)_CFNonObjCRetain((CFTypeRef)self); }
 - (NSUInteger)retainCount { return (NSUInteger)CFGetRetainCount((CFTypeRef)self); }
-- (oneway void)release { CFRelease((CFTypeRef)self); }
+- (oneway void)release { _CFNonObjCRelease((CFTypeRef)self); }
 - (void)dealloc { } // this is missing [super dealloc] on purpose, XCode
-- (NSUInteger)hash { return CFHash((CFTypeRef)self); }
+- (NSUInteger)hash { return _CFNonObjCHash((CFTypeRef)self); }
+- (BOOL)isEqual:(id)object {
+    return object && _CFNonObjCEqual((CFTypeRef)self, (CFTypeRef)object);
+}
 
 /*
  *    sjc -- 9/2/09 -- The format now matches Cocoa's. I thought.

--- a/PureFoundation/NSCFType.m
+++ b/PureFoundation/NSCFType.m
@@ -7,8 +7,9 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "ForFoundationOnly.h"
 
-// TODO: Need to work out whether we should bridge every non-bridged class to this class
+// Every non-bridged CF type reports itself as this class
 
 #define SELF    (CFTypeRef)self
 
@@ -22,19 +23,34 @@
 // t -[__NSCFType _isDeallocating]
 // t -[__NSCFType _tryRetain]
 
-// Standard bridged-class over-rides
-- (id)retain { return (id)CFRetain(SELF); }
-- (NSUInteger)retainCount { return CFGetRetainCount(SELF); }
-- (oneway void)release { CFRelease(SELF); }
+// The standard bridged-class over-rides
+// These allow CF types to interact with Foundation
+// The CFTYPE_IS_OBJC check specifically returns false for this class, so the CF codepath is taken
+
+- (id)retain {
+    return (id)_CFNonObjCRetain(SELF);
+}
+
+- (NSUInteger)retainCount {
+    return CFGetRetainCount(SELF);
+}
+
+- (oneway void)release {
+    _CFNonObjCRelease(SELF);
+}
+
 - (void)dealloc { } // this is missing [super dealloc] on purpose, XCode
-- (NSUInteger)hash { return CFHash(SELF); }
+
+- (NSUInteger)hash {
+    return _CFNonObjCHash(SELF);
+}
 
 - (NSString *)description {
     return [(id)CFCopyDescription(SELF) autorelease];
 }
 
 - (BOOL)isEqual:(id)object {
-    return [object isKindOfClass:[__NSCFType class]] && CFEqual(SELF, (CFTypeRef)object);
+    return object && _CFNonObjCEqual(SELF, (CFTypeID)object);
 }
 
 @end

--- a/PureFoundation/NSCalendar.m
+++ b/PureFoundation/NSCalendar.m
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "ForFoundationOnly.h"
 
 // TODO: Investigate
 // T __NSCalendarPreserveSmallerUnits
@@ -156,11 +157,14 @@
 }
 
 // Standard bridged-class over-rides
-- (id)retain { return (id)CFRetain((CFTypeRef)self); }
+- (id)retain { return (id)_CFNonObjCRetain((CFTypeRef)self); }
 - (NSUInteger)retainCount { return (NSUInteger)CFGetRetainCount((CFTypeRef)self); }
-- (oneway void)release { CFRelease((CFTypeRef)self); }
+- (oneway void)release { _CFNonObjCRelease((CFTypeRef)self); }
 - (void)dealloc { } // this is missing [super dealloc] on purpose, XCode
-- (NSUInteger)hash { return CFHash((CFTypeRef)self); }
+- (NSUInteger)hash { return _CFNonObjCHash((CFTypeRef)self); }
+- (BOOL)isEqual:(id)object {
+    return object && _CFNonObjCEqual((CFTypeRef)self, (CFTypeRef)object);
+}
 
 #pragma mark - NSCopying
 

--- a/PureFoundation/NSCharacterSet.m
+++ b/PureFoundation/NSCharacterSet.m
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "ForFoundationOnly.h"
 
 // NSCharacterSet, including all of the factory methods, are implemented in Foundation
 
@@ -30,11 +31,14 @@
 }
 
 // Standard bridged-class over-rides
-- (id)retain { return (id)CFRetain((CFTypeRef)self); }
+- (id)retain { return (id)_CFNonObjCRetain((CFTypeRef)self); }
 - (NSUInteger)retainCount { return (NSUInteger)CFGetRetainCount((CFTypeRef)self); }
-- (oneway void)release { CFRelease((CFTypeRef)self); }
+- (oneway void)release { _CFNonObjCRelease((CFTypeRef)self); }
 - (void)dealloc { } // this is missing [super dealloc] on purpose, XCode
-- (NSUInteger)hash { return CFHash((CFTypeRef)self); }
+- (NSUInteger)hash { return _CFNonObjCHash((CFTypeRef)self); }
+- (BOOL)isEqual:(id)object {
+    return object && _CFNonObjCEqual((CFTypeRef)self, (CFTypeRef)object);
+}
 
 - (NSString *)description {
     return [(id)CFCopyDescription((CFTypeRef)self) autorelease];
@@ -59,10 +63,6 @@
 }
 
 #pragma mark -
-
-- (BOOL)isEqual:(id)object {
-    return [object isKindOfClass:[self class]] && CFEqual((CFTypeRef)self, (CFTypeRef)object);
-}
 
 - (BOOL)characterIsMember:(unichar)aCharacter {
     return CFCharacterSetIsCharacterMember(SELF, (UniChar)aCharacter);

--- a/PureFoundation/NSData.m
+++ b/PureFoundation/NSData.m
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "ForFoundationOnly.h"
 
 // NSData and NSMutableData are declared here. All other methods are implemented in the NSData category in Foundation
 
@@ -40,11 +41,14 @@
 // t -[__NSCFData _tryRetain]
 
 // Standard bridged-class over-rides
-- (id)retain { return (id)CFRetain((CFTypeRef)self); }
+- (id)retain { return (id)_CFNonObjCRetain((CFTypeRef)self); }
 - (NSUInteger)retainCount { return (NSUInteger)CFGetRetainCount((CFTypeRef)self); }
-- (oneway void)release { CFRelease((CFTypeRef)self); }
+- (oneway void)release { _CFNonObjCRelease((CFTypeRef)self); }
 - (void)dealloc { } // this is missing [super dealloc] on purpose, XCode
-- (NSUInteger)hash { return CFHash((CFTypeRef)self); }
+- (NSUInteger)hash { return _CFNonObjCHash((CFTypeRef)self); }
+- (BOOL)isEqual:(id)object {
+    return object && _CFNonObjCEqual((CFTypeRef)self, (CFTypeRef)object);
+}
 
 - (NSString *)description {
     return [(id)CFCopyDescription((CFTypeRef)self) autorelease];

--- a/PureFoundation/NSDate.m
+++ b/PureFoundation/NSDate.m
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "ForFoundationOnly.h"
 
 // Coding happens in Foundation in the NSDate category
 
@@ -145,11 +146,14 @@
 }
 
 // Standard bridged-class over-rides
-- (id)retain { return (id)CFRetain((CFTypeRef)self); }
+- (id)retain { return (id)_CFNonObjCRetain((CFTypeRef)self); }
 - (NSUInteger)retainCount { return (NSUInteger)CFGetRetainCount((CFTypeRef)self); }
-- (oneway void)release { CFRelease((CFTypeRef)self); }
+- (oneway void)release { _CFNonObjCRelease((CFTypeRef)self); }
 - (void)dealloc { } // this is missing [super dealloc] on purpose, XCode
-- (NSUInteger)hash { return CFHash((CFTypeRef)self); }
+- (NSUInteger)hash { return _CFNonObjCHash((CFTypeRef)self); }
+- (BOOL)isEqual:(id)object {
+    return object && _CFNonObjCEqual((CFTypeRef)self, (CFTypeRef)object);
+}
 
 /*
  *    "A string representation of the receiver in the international format

--- a/PureFoundation/NSDictionary.m
+++ b/PureFoundation/NSDictionary.m
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "ForFoundationOnly.h"
 #import "PureFoundation.h"
 #import "FileLoaders.h"
 
@@ -360,11 +361,14 @@ static CFDictionaryRef PFDictionaryShallowCopyingValues(CFDictionaryRef dict, CF
 }
 
 // Standard bridged-class over-rides
-- (id)retain { return (id)CFRetain((CFTypeRef)self); }
+- (id)retain { return (id)_CFNonObjCRetain((CFTypeRef)self); }
 - (NSUInteger)retainCount { return (NSUInteger)CFGetRetainCount((CFTypeRef)self); }
-- (void)release { CFRelease((CFTypeRef)self); }
+- (oneway void)release { _CFNonObjCRelease((CFTypeRef)self); }
 - (void)dealloc { } // this is missing [super dealloc] on purpose, XCode
-- (NSUInteger)hash { return CFHash((CFTypeRef)self); }
+- (NSUInteger)hash { return _CFNonObjCHash((CFTypeRef)self); }
+- (BOOL)isEqual:(id)object {
+    return object && _CFNonObjCEqual((CFTypeRef)self, (CFTypeRef)object);
+}
 
 #pragma mark - NSFastEnumeration
 

--- a/PureFoundation/NSError.m
+++ b/PureFoundation/NSError.m
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "ForFoundationOnly.h"
 
 // __NSCFError is defined here in CoreFoundation. It is the class which is used to bridge to CFErrorRef.
 // NSError (and NSCFError, whatever that is) are defined in Foundation
@@ -52,10 +53,13 @@ static id PFErrorUserInfoValue(CFErrorRef error, NSString *key) {
 
 // Standard bridged-class over-rides
 - (void)dealloc {} // this is missing [super dealloc] on purpose, XCode
-- (id)retain { return (id)CFRetain((CFTypeRef)self); }
+- (id)retain { return (id)_CFNonObjCRetain((CFTypeRef)self); }
 - (NSUInteger)retainCount { return CFGetRetainCount((CFTypeRef)self); }
-- (oneway void)release { CFRelease((CFTypeRef)self); }
-- (NSUInteger)hash { return CFHash((CFTypeRef)self); }
+- (oneway void)release { _CFNonObjCRelease((CFTypeRef)self); }
+- (NSUInteger)hash { return _CFNonObjCHash((CFTypeRef)self); }
+- (BOOL)isEqual:(id)object {
+    return object && _CFNonObjCEqual((CFTypeRef)self, (CFTypeRef)object);
+}
 
 - (NSString *)localizedDescription {
     return [(id)CFErrorCopyDescription(SELF) autorelease];

--- a/PureFoundation/NSLocale.m
+++ b/PureFoundation/NSLocale.m
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "ForFoundationOnly.h"
 
 // TODO: Ensure that these are implemented somewhere
 // S _NSLocaleMeasurementSystemMetric
@@ -154,11 +155,14 @@
 }
 
 // Standard bridged-class over-rides
-- (id)retain { return (id)CFRetain((CFTypeRef)self); }
+- (id)retain { return (id)_CFNonObjCRetain((CFTypeRef)self); }
 - (NSUInteger)retainCount { return (NSUInteger)CFGetRetainCount((CFTypeRef)self); }
-- (oneway void)release { CFRelease((CFTypeRef)self); }
+- (oneway void)release { _CFNonObjCRelease((CFTypeRef)self); }
 - (void)dealloc { } // this is missing [super dealloc] on purpose, XCode
-- (NSUInteger)hash { return CFHash((CFTypeRef)self); }
+- (NSUInteger)hash { return _CFNonObjCHash((CFTypeRef)self); }
+- (BOOL)isEqual:(id)object {
+    return object && _CFNonObjCEqual((CFTypeRef)self, (CFTypeRef)object);
+}
 
 #pragma mark - NSCopying
 

--- a/PureFoundation/NSNumber.m
+++ b/PureFoundation/NSNumber.m
@@ -27,11 +27,14 @@
 }
 
 // Standard bridged-class over-rides
-- (id)retain { return (id)CFRetain((CFTypeRef)self); }
+- (id)retain { return (id)_CFNonObjCRetain((CFTypeRef)self); }
 - (NSUInteger)retainCount { return (NSUInteger)CFGetRetainCount((CFTypeRef)self); }
-- (oneway void)release { CFRelease((CFTypeRef)self); }
+- (oneway void)release { _CFNonObjCRelease((CFTypeRef)self); }
 - (void)dealloc { } // this is missing [super dealloc] on purpose, XCode
-- (NSUInteger)hash { return CFHash((CFTypeRef)self); }
+- (NSUInteger)hash { return _CFNonObjCHash((CFTypeRef)self); }
+- (BOOL)isEqual:(id)object {
+    return _CFNonObjCEqual((CFTypeRef)self, (CFTypeRef)object);
+}
 
 // TODO: Check whether numbers are still kept unique by CF
 - (id)copyWithZone:(NSZone *)zone {
@@ -253,11 +256,14 @@
 }
 
 //Standard bridged-class over-rides
-- (id)retain { return (id)CFRetain((CFTypeRef)self); }
+- (id)retain { return (id)_CFNonObjCRetain((CFTypeRef)self); }
 - (NSUInteger)retainCount { return (NSUInteger)CFGetRetainCount((CFTypeRef)self); }
-- (oneway void)release { CFRelease((CFTypeRef)self); }
+- (oneway void)release { _CFNonObjCRelease((CFTypeRef)self); }
 - (void)dealloc { } // this is missing [super dealloc] on purpose, XCode
-- (NSUInteger)hash { return CFHash((CFTypeRef)self); }
+- (NSUInteger)hash { return _CFNonObjCHash((CFTypeRef)self); }
+- (BOOL)isEqual:(id)object {
+    return object && _CFNonObjCEqual((CFTypeRef)self, (CFTypeRef)object);
+}
 
 - (id)copyWithZone:(NSZone *)zone {
     return self; // because these are constants

--- a/PureFoundation/NSObject.m
+++ b/PureFoundation/NSObject.m
@@ -9,6 +9,18 @@
 #import <Foundation/Foundation.h>
 
 // NSObject is defined in libobjc
+
+@interface NSObject (__NSCFType)
+- (CFTypeID)_cfTypeID;
+@end
+
+@implementation NSObject (__NSCFType)
+- (CFTypeID)_cfTypeID {
+    return 1; // == __kCFTypeTypeID
+}
+@end
+
+
 // TODO: Need to indeirect export NSObject
 
 /*
@@ -75,6 +87,3 @@ I _OBJC_METACLASS_$_NSObject (indirect for _OBJC_METACLASS_$_NSObject)
 0000000000097e20 t -[NSObject(NSObject) methodSignatureForSelector:]
 */
 
-/*
-0000000000055d50 t -[NSObject(__NSCFType) _cfTypeID]
-*/

--- a/PureFoundation/NSStream.m
+++ b/PureFoundation/NSStream.m
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "ForFoundationOnly.h"
 #import "CFStreamPriv.h"
 
 #define RSTREAM     ((CFReadStreamRef)self)
@@ -58,11 +59,14 @@ static void _PFWriteStreamCB(CFWriteStreamRef stream, CFStreamEventType eventTyp
 }
 
 // Standard bridged-class over-rides
-- (id)retain { return (id)CFRetain((CFTypeRef)self); }
+- (id)retain { return (id)_CFNonObjCRetain((CFTypeRef)self); }
 - (NSUInteger)retainCount { return (NSUInteger)CFGetRetainCount((CFTypeRef)self); }
-- (oneway void)release { CFRelease((CFTypeRef)self); }
+- (oneway void)release { _CFNonObjCRelease((CFTypeRef)self); }
 - (void)dealloc { } // this is missing [super dealloc] on purpose, XCode
-- (NSUInteger)hash { return CFHash((CFTypeRef)self); }
+- (NSUInteger)hash { return _CFNonObjCHash((CFTypeRef)self); }
+- (BOOL)isEqual:(id)object {
+    return object && _CFNonObjCEqual((CFTypeRef)self, (CFTypeRef)object);
+}
 
 - (NSString *)description {
     return [(id)CFCopyDescription((CFTypeRef)self) autorelease];
@@ -137,11 +141,14 @@ static void _PFWriteStreamCB(CFWriteStreamRef stream, CFStreamEventType eventTyp
 }
 
 // Standard bridged-class over-rides
-- (id)retain { return (id)CFRetain((CFTypeRef)self); }
+- (id)retain { return (id)_CFNonObjCRetain((CFTypeRef)self); }
 - (NSUInteger)retainCount { return (NSUInteger)CFGetRetainCount((CFTypeRef)self); }
-- (oneway void)release { CFRelease((CFTypeRef)self); }
+- (oneway void)release { _CFNonObjCRelease((CFTypeRef)self); }
 - (void)dealloc { } // this is missing [super dealloc] on purpose, XCode
-- (NSUInteger)hash { return CFHash((CFTypeRef)self); }
+- (NSUInteger)hash { return _CFNonObjCHash((CFTypeRef)self); }
+- (BOOL)isEqual:(id)object {
+    return object && _CFNonObjCEqual((CFTypeRef)self, (CFTypeRef)object);
+}
 
 -(NSString *)description {
     return [(id)CFCopyDescription((CFTypeRef)self) autorelease];

--- a/PureFoundation/NSString.m
+++ b/PureFoundation/NSString.m
@@ -7,9 +7,10 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "ForFoundationOnly.h"
 #import "PureFoundation.h"
 
-// Hmm... NSString and NSMutableString are implemented in Foundation, but the bridged class __NSCFString is implemented here
+// NSString and NSMutableString are implemented in Foundation, but the bridged class __NSCFString is implemented here
 
 #define SELF ((CFStringRef)self)
 #define MSELF ((CFMutableStringRef)self)
@@ -37,11 +38,14 @@
 // TODO: implement -classForCoder
 
 // Standard bridged-class over-rides
-- (id)retain { return (id)CFRetain((CFTypeRef)self); }
+- (id)retain { return (id)_CFNonObjCRetain((CFTypeRef)self); }
 - (NSUInteger)retainCount { return (NSUInteger)CFGetRetainCount((CFTypeRef)self); }
-- (oneway void)release { CFRelease((CFTypeRef)self); }
+- (oneway void)release { _CFNonObjCRelease((CFTypeRef)self); }
 - (void)dealloc { } // this is missing [super dealloc] on purpose, XCode
-- (NSUInteger)hash { return CFHash((CFTypeRef)self); }
+- (NSUInteger)hash { return _CFNonObjCHash((CFTypeRef)self); }
+//- (BOOL)isEqual:(id)object {
+//    return object && _CFNonObjCEqual((CFTypeRef)self, (CFTypeRef)object);
+//}
 
 - (NSString *)description {
     return [(id)CFRetain(SELF) autorelease];
@@ -1177,6 +1181,9 @@
 - (NSUInteger)retainCount { return NSIntegerMax; }
 - (id)copyWithZone:(NSZone *)zone { return self; }
 - (BOOL)isNSCFConstantString__ { return YES; }
+- (NSUInteger)hash {
+    return _CFNonObjCHash((CFTypeRef)self);
+}
 @end
 
 

--- a/PureFoundation/NSTimeZone.m
+++ b/PureFoundation/NSTimeZone.m
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "ForFoundationOnly.h"
 
 // TODO: Check that this is defined somewhere
 // S _NSSystemTimeZoneDidChangeNotification
@@ -104,11 +105,14 @@
 }
 
 // Standard bridged-class over-rides
-- (id)retain { return (id)CFRetain((CFTypeRef)self); }
+- (id)retain { return (id)_CFNonObjCRetain((CFTypeRef)self); }
 - (NSUInteger)retainCount { return (NSUInteger)CFGetRetainCount((CFTypeRef)self); }
-- (oneway void)release { CFRelease((CFTypeRef)self); }
+- (oneway void)release { _CFNonObjCRelease((CFTypeRef)self); }
 - (void)dealloc { } // this is missing [super dealloc] on purpose, XCode
-- (NSUInteger)hash { return CFHash((CFTypeRef)self); }
+- (NSUInteger)hash { return _CFNonObjCHash((CFTypeRef)self); }
+- (BOOL)isEqual:(id)object {
+    return object && _CFNonObjCEqual((CFTypeRef)self, (CFTypeRef)object);
+}
 
 - (NSString *)description {
     return [(id)CFCopyDescription((CFTypeRef)self) autorelease];

--- a/PureFoundation/NSTimer.m
+++ b/PureFoundation/NSTimer.m
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "ForFoundationOnly.h"
 
 // NSTimer is declared here, but all its methods are implemented in Foundation
 
@@ -67,11 +68,14 @@
 }
 
 // Standard bridged-class over-rides
-- (id)retain { return (id)CFRetain((CFTypeRef)self); }
+- (id)retain { return (id)_CFNonObjCRetain((CFTypeRef)self); }
 - (NSUInteger)retainCount { return (NSUInteger)CFGetRetainCount((CFTypeRef)self); }
-- (oneway void)release { CFRelease((CFTypeRef)self); }
+- (oneway void)release { _CFNonObjCRelease((CFTypeRef)self); }
 - (void)dealloc { } // this is missing [super dealloc] on purpose, XCode
-- (NSUInteger)hash { return CFHash((CFTypeRef)self); }
+- (NSUInteger)hash { return _CFNonObjCHash((CFTypeRef)self); }
+- (BOOL)isEqual:(id)object {
+    return object && _CFNonObjCEqual((CFTypeRef)self, (CFTypeRef)object);
+}
 
 - (NSString *)description {
     return [(id)CFCopyDescription((CFTypeRef)self) autorelease];


### PR DESCRIPTION
This PR:
* Implements `__NSCFType`, used to bridge CF types to objective-C
* Restores objective-c dispatch code path to `CFRetain()`, `CFRelease()`, `CFHash()` and other primitive functions
* Implements `NSBlock` and its subclasses which allow dispatch blocks to act as objective-c objects
* Fixed bridged CF types to avoid objective-c lookup 